### PR TITLE
Fix the `tag-callback` keyword

### DIFF
--- a/dev/cl-html-parse.lisp
+++ b/dev/cl-html-parse.lisp
@@ -1059,7 +1059,7 @@
 		  no-body-tags parse-entities))
 
 (defmacro tag-callback (tag)
-  `(rest (assoc ,tag callbacks)))
+  `(cadr (assoc ,tag callbacks)))
 
 (defun phtml-internal (p read-sequence-func callback-only 
 		       callbacks collect-rogue-tags 


### PR DESCRIPTION
Make the macro expand to `cadr` instead of `rest` to get the value, not a list of the value. Without this change, you get an error when you try to use the keyword.